### PR TITLE
Refactor in customized template and alter menu app location

### DIFF
--- a/disable_odoo_online/__manifest__.py
+++ b/disable_odoo_online/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Remove odoo.com Bindings",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Therp BV,GRAP,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "base",

--- a/disable_odoo_online/static/src/xml/base.xml
+++ b/disable_odoo_online/static/src/xml/base.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-extend="UserMenu">
+    <t t-extend="UserMenu.Actions">
         <t t-jquery="a[data-menu='account'], a[data-menu='documentation'], a[data-menu='support']">
             this.parent().remove();
         </t>

--- a/disable_odoo_online/views/ir_ui_menu.xml
+++ b/disable_odoo_online/views/ir_ui_menu.xml
@@ -5,4 +5,8 @@
         <field name="parent_id" ref="base.menu_ir_property"/>
     </record>
 
+    <record model="ir.ui.menu" id="base.module_mi">
+        <field name="parent_id" ref="base.menu_ir_property"/>
+    </record>
+
 </odoo>


### PR DESCRIPTION
This PR have two simple modifications in disable_odoo_online module to correct the following problems:

  - After install module, references from odoo.com continue inside preferences menu of user, because the template used to remove them (UserMenu) has other id(UserMenu.Actions):

![2018-04-06 14-56-24](https://user-images.githubusercontent.com/15001160/38437251-447c3cdc-39ad-11e8-987b-9b0cd49da38f.png)

  - Only updates menu item in settings is hidden inside technical parameters menu, the app menu still visible in settings:

![2018-04-06 14-58-49](https://user-images.githubusercontent.com/15001160/38437559-3a409c3a-39ae-11e8-8e72-d04248c66891.png)
