### PR TITLE
[FIX] remove_odoo_enterprise : remove auto_install

### DIFF
--- a/remove_odoo_enterprise/__manifest__.py
+++ b/remove_odoo_enterprise/__manifest__.py
@@ -15,5 +15,5 @@
         'data/ir_module_module.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
the module ``remove_odoo_enterprise`` depends on ``base`` module only and is auto_installable.

This makes this module installed by default, if the repository is present in the addons path. I don't think that's is a good design.

propose to set auto install to False.

CC :

@badbole, @levkar : original contributors.
@tarteo : OCA#16
