### PR TITLE
Remove "About" section in "Settings"

### DIFF
--- a/disable_odoo_online/__manifest__.py
+++ b/disable_odoo_online/__manifest__.py
@@ -8,7 +8,10 @@
     "license": "AGPL-3",
     "category": "base",
     "depends": ["mail"],
-    "data": ["views/ir_ui_menu.xml"],
+    "data": [
+        "views/ir_ui_menu.xml",
+        "views/res_config_settings_views.xml"
+    ],
     "qweb": ["static/src/xml/base.xml"],
     "installable": True,
 }

--- a/disable_odoo_online/views/res_config_settings_views.xml
+++ b/disable_odoo_online/views/res_config_settings_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.disable_odoo_online</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <div id='about' position="replace"/>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
By inheriting "base_setup.res_config_settings_view_form" we replaced the about section with nothing. This results in removal of this section. 