### PR TITLE
@api.multi removed

### DIFF
--- a/disable_odoo_online/models/publisher_warranty_contract.py
+++ b/disable_odoo_online/models/publisher_warranty_contract.py
@@ -8,7 +8,6 @@ from odoo.release import version_info
 class PublisherWarrantyContract(models.AbstractModel):
     _inherit = 'publisher_warranty.contract'
 
-    @api.multi
     def update_notification(self, cron_mode=True):
         if version_info[5] == 'e':
             return super(PublisherWarrantyContract, self).update_notification(


### PR DESCRIPTION
According with the Migration guide.

Remove all the decorators @api.multi, @api.returns, @api.one, @api.cr, @api.model_cr from the code. Now they are all multi-record by default. In case of the last ones, you will need to adapt the code to the behavior change.