### PR TITLE
[12.0] hide instead of remove odoo enterprise

### DIFF
--- a/remove_odoo_enterprise/models/res_config_settings.py
+++ b/remove_odoo_enterprise/models/res_config_settings.py
@@ -29,7 +29,7 @@ class ResConfigSettings(models.TransientModel):
 
         query = "//div[div[field[@widget='upgrade_boolean']]]"
         for item in doc.xpath(query):
-            item.getparent().remove(item)
+            item.attrib["style"] = "display:none"
 
         ret_val['arch'] = etree.tostring(doc)
         return ret_val


### PR DESCRIPTION
Hide the Odoo Enterprise upgrade boxes instead of removing them
from the xml. The reason is that removing an element can cause incompatibility
issues with other modules that target this element.

For example, the OCA module account_budget_template targets one of these elements.
https://github.com/OCA/account-budgeting/commit/05b9e7c7fb88e263dc332497d6166cf341214505#diff-c8abe70a35b89d535c5ba80ec7966cc4bacea5debf06dc7cef734c2f76d1ba9bR9