### PR TITLE
[16.0][IMP] remove_odoo_enterprise: hide Google Play and Apple Store

### DIFF
--- a/remove_odoo_enterprise/__manifest__.py
+++ b/remove_odoo_enterprise/__manifest__.py
@@ -8,6 +8,7 @@
     "author": "Eska, Onestein, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-brand",
     "license": "AGPL-3",
-    "depends": ["base"],
+    "depends": ["base_setup"],
+    "data": ["views/res_config_settings_views.xml"],
     "installable": True,
 }

--- a/remove_odoo_enterprise/readme/DESCRIPTION.rst
+++ b/remove_odoo_enterprise/readme/DESCRIPTION.rst
@@ -1,1 +1,4 @@
 This module removes enterprise-only apps and features from all settings views.
+
+It also removes the widget in the General Settings page for downloading the Odoo
+mobile apps from Google Play and Apple Store.

--- a/remove_odoo_enterprise/tests/test_remove_odoo_enterprise.py
+++ b/remove_odoo_enterprise/tests/test_remove_odoo_enterprise.py
@@ -1,7 +1,9 @@
-# Copyright 2020 Onestein (<http://www.onestein.eu>)
+# Copyright 2020-2023 Onestein (<http://www.onestein.eu>)
 # Copyright 2020 Akretion (<http://www.akretion.com>)
 # Copyright 2023 Le Filament (https://le-filament.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import json
 
 from lxml import etree
 
@@ -26,3 +28,28 @@ class TestRemoveOdooEnterprise(common.TransactionCase):
     def test_search_ir_module(self):
         module_ids = self.env["ir.module.module"].search([])
         self.assertFalse(any([m.to_buy for m in module_ids]))
+
+    def test_appstore_invisible(self):
+        """The appstore widget is invisible"""
+        conf = self.env["res.config.settings"].create({})
+        view = conf.get_views([[False, "form"]])["views"]["form"]
+        doc = etree.XML(view["arch"])
+
+        query = "//div[@id='appstore']"
+        for item in doc.xpath(query):
+            invisible_attrib = json.loads(item.attrib["modifiers"])
+            self.assertTrue(invisible_attrib["invisible"])
+
+    def test_appstore_visible(self):
+        """Disabling the view makes the appstore widget visible again"""
+        conf_form_view = self.env.ref(
+            "remove_odoo_enterprise.res_config_settings_view_form"
+        )
+        conf_form_view.active = False
+        conf = self.env["res.config.settings"].create({})
+        view = conf.get_views([[False, "form"]])["views"]["form"]
+        doc = etree.XML(view["arch"])
+
+        query = "//div[@id='appstore']"
+        for item in doc.xpath(query):
+            self.assertNotIn("modifiers", item.attrib)

--- a/remove_odoo_enterprise/views/res_config_settings_views.xml
+++ b/remove_odoo_enterprise/views/res_config_settings_views.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='appstore']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
As discussed in https://github.com/OCA/server-brand/pull/66, I'm hereby proposing the removal of the widget Google Play and Apple Store in the General Settings.

CC @pedrobaeza 
