### PR TITLE
[IMP][remove_odoo_enterprise] Hide block title if empty

### DIFF
--- a/remove_odoo_enterprise/models/res_config_settings.py
+++ b/remove_odoo_enterprise/models/res_config_settings.py
@@ -25,5 +25,12 @@ class ResConfigSettings(models.TransientModel):
         for item in doc.xpath(query):
             item.attrib["class"] = "d-none"
 
+        for container in doc.xpath("//div[contains(@class, 'o_settings_container')]"):
+            if len(container.xpath("div[not(contains(@class, 'd-none'))]")) == 0:
+                prev_el = container.getprevious()
+                if len(prev_el) and prev_el.tag == "h2":
+                    prev_el.attrib["class"] = "d-none"
+                container.attrib["class"] = "d-none"
+
         ret_val["views"]["form"]["arch"] = etree.tostring(doc)
         return ret_val


### PR DESCRIPTION
Hide the whole block (title included) if no more elements exists in the block.

Without remove_odoo_enterprise addon
![image](https://github.com/OCA/server-brand/assets/4457345/51f7cb20-22f8-4afa-a28f-a4e7c829f838)

With remove_odoo_enterprise addon but without my modifications
![image](https://github.com/OCA/server-brand/assets/4457345/6b25bd37-65f5-49f1-9545-80f52f543c83)

With remove_odoo_enterprise addon and my modifications
![image](https://github.com/OCA/server-brand/assets/4457345/a9b0dfbb-a389-49e2-a394-4c5a37ebe2c4)

