### PR TITLE
[16.0][FIX] remove_odoo_enterprise: Fixed the logic to hide enterprise setings, to prevent broken settings views.

### DIFF
--- a/remove_odoo_enterprise/models/res_config_settings.py
+++ b/remove_odoo_enterprise/models/res_config_settings.py
@@ -2,7 +2,6 @@
 # Copyright 2018-2020 Onestein (<http://www.onestein.eu>)
 # Copyright 2023 Le Filament (https://le-filament.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from lxml import etree
 
 from odoo import api, models
@@ -13,29 +12,48 @@ class ResConfigSettings(models.TransientModel):
 
     @api.model
     def get_views(self, views, options=None):
-        ret_val = super().get_views(views, options)
+        """Override to hide settings related to enterprise features.
 
-        form_view = self.env["ir.ui.view"].browse(ret_val["views"]["form"]["id"])
+        This method modifies the form view for settings to hide options
+        that require enterprise version of Odoo.
+        """
+        result = super().get_views(views, options)
 
-        view_xml_ids = (
-            form_view.xml_id,
-            form_view.inherit_id.xml_id,
+        doc = etree.XML(result["views"]["form"]["arch"])
+
+        # Hide all setting boxes containing upgrade_boolean widgets
+        self._hide_enterprise_settings(doc)
+
+        # Hide empty setting containers and their headings
+        self._hide_empty_containers(doc)
+
+        # Update the form view architecture with the modified XML
+        result["views"]["form"]["arch"] = etree.tostring(doc)
+        return result
+
+    def _hide_enterprise_settings(self, doc):
+        """Hide all setting boxes containing upgrade_boolean widgets."""
+        # Find all setting boxes with upgrade_boolean widgets
+        query = (
+            "//div[contains(@class, 'o_setting_box')]"
+            "[.//field[@widget='upgrade_boolean']]"
         )
-        if "base.res_config_settings_view_form" not in view_xml_ids:
-            return ret_val
+        for setting_box in doc.xpath(query):
+            setting_box.attrib["class"] = "d-none"
 
-        doc = etree.XML(ret_val["views"]["form"]["arch"])
+    def _hide_empty_containers(self, doc):
+        """Hide containers that no longer have any visible setting boxes."""
+        # Find containers with no visible setting boxes
+        empty_container_query = (
+            "//div[contains(@class, 'o_settings_container')]"
+            "[not(.//div[contains(@class, 'o_setting_box') "
+            "and not(contains(@class, 'd-none'))])]"
+        )
 
-        query = "//div[div[field[@widget='upgrade_boolean']]]"
-        for item in doc.xpath(query):
-            item.attrib["class"] = "d-none"
-
-        for container in doc.xpath("//div[contains(@class, 'o_settings_container')]"):
-            if len(container.xpath("div[not(contains(@class, 'd-none'))]")) == 0:
-                prev_el = container.getprevious()
-                if len(prev_el) and prev_el.tag == "h2":
-                    prev_el.attrib["class"] = "d-none"
-                container.attrib["class"] = "d-none"
-
-        ret_val["views"]["form"]["arch"] = etree.tostring(doc)
-        return ret_val
+        for empty_container in doc.xpath(empty_container_query):
+            # If there's a heading before the container, hide it too
+            prev_element = empty_container.getprevious()
+            if prev_element is not None and prev_element.tag == "h2":
+                prev_element.attrib["class"] = "d-none"
+            # Hide the empty container
+            empty_container.attrib["class"] = "d-none"

--- a/remove_odoo_enterprise/tests/test_remove_odoo_enterprise.py
+++ b/remove_odoo_enterprise/tests/test_remove_odoo_enterprise.py
@@ -12,20 +12,107 @@ from odoo.tests import common
 
 class TestRemoveOdooEnterprise(common.TransactionCase):
     def test_res_config_settings(self):
+        """
+        This test case checks the XML architecture of res.config.settings view,
+        specifically searching for div elements with a field element where widget
+        attribute is 'upgrade_boolean'. If such an element exists, it should have
+        the class "d-none".
+        """
         conf = self.env["res.config.settings"].create({})
         view = conf.get_views([[False, "form"]])["views"]["form"]
         doc = etree.XML(view["arch"])
 
         query = "//div[div[field[@widget='upgrade_boolean']]]"
         for item in doc.xpath(query):
-            self.assertEqual(item.attrib["class"], "d-none")
+            self.assertIn("d-none", item.attrib["class"])
 
-    def test_search_base(self):
+    def test_hide_empty_containers(self):
+        """Test the _hide_empty_containers method"""
+        conf = self.env["res.config.settings"].create({})
+
+        # Create a test XML document with empty containers
+        xml_content = """
+        <form>
+            <h2>Heading 1</h2>
+            <div class="o_settings_container">
+                <div class="o_setting_box d-none">Hidden setting box</div>
+            </div>
+            <h2>Heading 2</h2>
+            <div class="o_settings_container">
+                <div class="o_setting_box">Visible setting box</div>
+            </div>
+            <h2>Heading 3</h2>
+            <div class="o_settings_container">
+                <div class="o_setting_box d-none">Another hidden setting box</div>
+            </div>
+        </form>
+        """
+        doc = etree.XML(xml_content)
+
+        # Apply the method to hide empty containers
+        conf._hide_empty_containers(doc)
+
+        # Check that empty containers and their headings are hidden
+        empty_containers = doc.xpath("//div[@class='d-none']")
+        self.assertEqual(len(empty_containers), 2)
+
+        # Check that headings before empty containers are hidden
+        hidden_headings = doc.xpath("//h2[@class='d-none']")
+        self.assertEqual(len(hidden_headings), 2)
+        self.assertEqual(hidden_headings[0].text, "Heading 1")
+        self.assertEqual(hidden_headings[1].text, "Heading 3")
+
+        # Check that containers with visible setting boxes are not hidden
+        visible_containers = doc.xpath("//div[@class='o_settings_container']")
+        self.assertEqual(len(visible_containers), 1)
+
+    def test_hide_enterprise_settings(self):
+        """Test the _hide_enterprise_settings method"""
+        conf = self.env["res.config.settings"].create({})
+
+        # Create a test XML document with upgrade_boolean widgets
+        xml_content = """
+        <form>
+            <div class="o_setting_box">
+                <div>
+                    <field name="show_effect" widget="upgrade_boolean"/>
+                </div>
+            </div>
+            <div class="o_setting_box">
+                <div>
+                    <field name="field2"/>
+                </div>
+            </div>
+        </form>
+        """
+        doc = etree.XML(xml_content)
+
+        # Apply the method to hide enterprise settings
+        conf._hide_enterprise_settings(doc)
+
+        # Check that setting boxes with upgrade_boolean widgets are hidden
+        hidden_boxes = doc.xpath("//div[@class='d-none']")
+        self.assertEqual(len(hidden_boxes), 1)
+
+        # Check that other setting boxes are not hidden
+        visible_boxes = doc.xpath("//div[@class='o_setting_box']")
+        self.assertEqual(len(visible_boxes), 1)
+
+    def test_search_payment_providers(self):
+        """
+        This function checks if there are any payment providers in the database,
+        fetches them using a search query, and then verifies that none of these
+        providers have an associated module to buy.
+        """
         if self.env.get("payment.provider"):
             acquirer_ids = self.env["payment.provider"].search([])
             self.assertFalse(any([a.module_to_buy for a in acquirer_ids]))
 
     def test_search_ir_module(self):
+        """
+        This function is used to test the search method from 'ir.module.module' model.
+        It checks if there are any modules without a purchase cost (to_buy = False).
+        """
         module_ids = self.env["ir.module.module"].search([])
         self.assertFalse(any([m.to_buy for m in module_ids]))
 


### PR DESCRIPTION
### Issue

The current logic in remove_odoo_enterprise regarding the res settings is not robust enough and therefore can lead to unexpected behaviours, if settings forms do not exactly look like expected.

One concrete example: remove_odoo_enterprise breaks the settings view of odoo core module website_slides. There they use groups as first element in settings_container

![image](https://github.com/user-attachments/assets/5d77e591-9430-498e-80e3-e6cd32c33caf)

This situation is not handled properly in remove_odoo_enterprise and the result is a broken / empty form:

![image](https://github.com/user-attachments/assets/372f7901-14e9-4533-98a3-0c648cd471c3)

And also the search is broken. When typing something in the search bar, an js error occurs:

OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    OwlError@
    handleError@http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1484:113
    _render@http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1509:30
    render@http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1507:13
    @http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1597:35

Caused by: TypeError: undefined is not an object (evaluating 'this.state.showAllContainer.showAllContainer')
    visible@http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/1036-fbf7917/web.assets_backend.min.js:6215:31
    template@
    _render@http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1508:104
    render@http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1507:13
    @http://oca-server-brand-16-0-749361a09185.runboat.odoo-community.org/web/assets/780-8b11573/web.assets_common.min.js:1597:35

### Solution

Make the code more robust.

### Steps to reproduce 

1. Install remove_odoo_enterprise and website_slides
2. Open the settings for "eLearning" --> Form is empty
3. Type something in the res settings search bar --> Error message appears
